### PR TITLE
Add optional CSP nonce support to session_check script tag

### DIFF
--- a/app/views/_session_check.html.erb
+++ b/app/views/_session_check.html.erb
@@ -1,4 +1,4 @@
-<script>
+<script<% if local_assigns[:nonce] %> nonce="<%= nonce %>"<% end %>>
     var SessionCheck = {
         should_session_check: <%= !current_user.nil? %>
     };

--- a/spec/session/check/engine_spec.rb
+++ b/spec/session/check/engine_spec.rb
@@ -13,6 +13,18 @@ describe Session::Check::Engine do
     expect(result).to include("session_time")
   end
 
+  it "renders the script tag without a nonce by default" do
+    instance = ActionController::Base.new
+    result = instance.session_check
+    expect(result).to include("<script>")
+  end
+
+  it "renders the script tag with a nonce when provided" do
+    instance = ActionController::Base.new
+    result = instance.session_check(nonce: "abc123")
+    expect(result).to include('nonce="abc123"')
+  end
+
   it "has a to_prepare block that adds the helper to a subclass of ActionController::Base" do
     instance = SomeController.new
     result = instance.session_check


### PR DESCRIPTION
## Summary

Adds an optional `nonce` parameter to the `_session_check` partial so it can be used with Content Security Policies that use nonces.

When a nonce is present in `script-src`, browsers (CSP Level 2+) ignore `'unsafe-inline'`, meaning the session check script would be blocked without a nonce.

## Usage

Pass the nonce when calling the helper:

```erb
<%= session_check(reset_counter_on_ajax: false, check_every: 60, nonce: content_security_policy_nonce) %>
```

If no nonce is passed, the behaviour is unchanged (fully backwards compatible).

## Change

The `<script` tag now conditionally includes a `nonce` attribute:

```erb
<script<% if local_assigns[:nonce] %> nonce="<%= nonce %>"<% end %>>
```