### PR TITLE
Fix setTimeout multiplier (5000 → 1000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ their browser, you can start the ping process by calling:
 
 # Changelog
 
+Version 1.1.1 : Fixed setTimeout multiplier (5000 → 1000) so session checks fire at the correct interval
 Version 1.1.0 : Added optional nonce
 Version 0.2.1 : Added explicit reference to Devise (which is required)

--- a/app/views/_session_check.html.erb
+++ b/app/views/_session_check.html.erb
@@ -21,9 +21,9 @@
                         })
                         .fail(force_sign_in);
             }
-            setTimeout(session_check, check_every_s * 5000);
+            setTimeout(session_check, check_every_s * 1000);
         };
-        setTimeout(session_check, check_every_s * 5000);
+        setTimeout(session_check, check_every_s * 1000);
         <% if reset_counter_on_ajax %>
         $.ajaxSetup({
             complete: function (xhr) {

--- a/lib/session/check/version.rb
+++ b/lib/session/check/version.rb
@@ -2,6 +2,6 @@
 
 module Session
   module Check
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end

--- a/spec/session/check/engine_spec.rb
+++ b/spec/session/check/engine_spec.rb
@@ -25,6 +25,12 @@ describe Session::Check::Engine do
     expect(result).to include('nonce="abc123"')
   end
 
+  it "uses a 1000ms multiplier for setTimeout so check_every (in seconds) converts correctly to milliseconds" do
+    instance = ActionController::Base.new
+    result = instance.session_check
+    expect(result).to include("check_every_s * 1000")
+  end
+
   it "has a to_prepare block that adds the helper to a subclass of ActionController::Base" do
     instance = SomeController.new
     result = instance.session_check


### PR DESCRIPTION
`check_every_s` is in seconds, but `setTimeout` expects milliseconds. The multiplier was incorrectly set to `5000`, causing session checks to fire 5× less frequently than configured.

- Fix `check_every_s * 5000` → `check_every_s * 1000` in `_session_check.html.erb` (both `setTimeout` calls)
- Add a spec asserting the rendered output uses the correct `* 1000` multiplier