### PR TITLE
Prevent current_user from triggering a Warden timeout error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    session-check (2.0.1)
+    session-check (2.0.2)
       devise
       rails (>= 5.0)
 

--- a/lib/session/check/configuration.rb
+++ b/lib/session/check/configuration.rb
@@ -15,14 +15,24 @@ module Session
         @logged_out_url = '/users/sign_in'
         @check_every_s = 10
         @session_active_proc = ->(controller) {
-          user = begin
-            controller.current_user
+          # Fetch the Warden user directly, with `run_callbacks: false`, instead of calling
+          # `controller.current_user`. Devise's Timeoutable module hooks into Warden's
+          # `after_set_user` callback (triggered by `current_user`/`authenticate`) and, when the
+          # session has actually timed out, signs the user out and does
+          # `throw :warden, message: :timeout`. Since this endpoint is JSON-only, that throw is
+          # handled by Warden's failure app as a 401 response rather than the plain
+          # `{ exists: false }` payload this proc is supposed to return, so callers ended up
+          # seeing a 401 instead of a graceful "session no longer active" result. Skipping
+          # callbacks avoids triggering that sign-out/401 side effect on every check.
+          warden = begin
+            controller.request.env['warden']
           rescue NoMethodError
             nil
           end
+          user = warden&.user(scope: :user, run_callbacks: false)
           if user
             expires_in = Session::Check::Devise.expires_in(controller.session)
-            { exists: true, expires_in: expires_in }
+            { exists: expires_in.positive?, expires_in: expires_in }
           else
             { exists: false, expires_in: 0 }
           end

--- a/lib/session/check/version.rb
+++ b/lib/session/check/version.rb
@@ -2,6 +2,6 @@
 
 module Session
   module Check
-    VERSION = '2.0.1'
+    VERSION = '2.0.2'
   end
 end

--- a/spec/requests/session/check/session_checks_controller_spec.rb
+++ b/spec/requests/session/check/session_checks_controller_spec.rb
@@ -1,18 +1,47 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "warden/test/helpers"
 
 describe Session::Check::SessionChecksController, type: :request do
+  include Warden::Test::Helpers
+
+  after(:each) { Warden.test_reset! }
+
   around(:each) do |example|
     Timecop.freeze { example.run }
   end
 
+  let(:user) do
+    User.find_or_create_by!(email: "user@example.com") { |u| u.password = "password123" }
+  end
+
   describe "#time_to_session_expiry" do
     context "with the default session_active_proc" do
-      it "returns session_exists: true and Devise.timeout_in when a user is present" do
+      it "returns session_exists: true and Devise.timeout_in when a user is signed in" do
+        login_as user, scope: :user
         get "/session_check/time_to_session_expiry"
         result = JSON.parse(response.body)
         expect(result).to eq({ "session_exists" => true, "session_expires_in" => Devise.timeout_in.to_i })
+      end
+
+      it "returns session_exists: false when no user is signed in" do
+        get "/session_check/time_to_session_expiry"
+        result = JSON.parse(response.body)
+        expect(result).to eq({ "session_exists" => false, "session_expires_in" => 0 })
+      end
+
+      it "returns 200 with session_exists: false, rather than a 401, once the Devise session " \
+        "has timed out" do
+        login_as user, scope: :user
+        get "/session_check/time_to_session_expiry" # first request lands the login_as session
+
+        Timecop.travel(Devise.timeout_in.from_now + 60) do
+          get "/session_check/time_to_session_expiry"
+          expect(response.status).to eq(200)
+          result = JSON.parse(response.body)
+          expect(result).to eq({ "session_exists" => false, "session_expires_in" => 0 })
+        end
       end
     end
 

--- a/spec/session/check/configuration_spec.rb
+++ b/spec/session/check/configuration_spec.rb
@@ -11,13 +11,18 @@ describe Session::Check::Configuration do
     end
 
     context "default proc" do
-      let(:controller) { double("controller") }
+      let(:warden) { double("warden") }
+      let(:controller) do
+        double("controller").tap do |c|
+          allow(c).to receive_message_chain(:request, :env).and_return({ 'warden' => warden })
+        end
+      end
 
-      it "returns exists: true and remaining session time when current_user is present" do
+      it "returns exists: true and remaining session time when a warden user is present" do
         elapsed = 60
         last_request_at = Time.now.utc.to_i - elapsed
         warden_session = { 'last_request_at' => last_request_at }
-        allow(controller).to receive(:current_user).and_return(double("user"))
+        allow(warden).to receive(:user).with(scope: :user, run_callbacks: false).and_return(double("user"))
         allow(controller).to receive(:session).and_return({ 'warden.user.user.session' => warden_session })
         result = config.session_active_proc.call(controller)
         expected_expires_in = Devise.timeout_in.to_i - elapsed
@@ -26,15 +31,35 @@ describe Session::Check::Configuration do
       end
 
       it "falls back to full timeout when warden session data is unavailable" do
-        allow(controller).to receive(:current_user).and_return(double("user"))
+        allow(warden).to receive(:user).with(scope: :user, run_callbacks: false).and_return(double("user"))
         allow(controller).to receive(:session).and_return({})
         result = config.session_active_proc.call(controller)
         expect(result[:exists]).to eq(true)
         expect(result[:expires_in]).to be_within(2).of(Devise.timeout_in.to_i)
       end
 
-      it "returns exists: false and 0 when current_user is nil" do
-        allow(controller).to receive(:current_user).and_return(nil)
+      it "returns exists: false and 0 when there is no warden user" do
+        allow(warden).to receive(:user).with(scope: :user, run_callbacks: false).and_return(nil)
+        result = config.session_active_proc.call(controller)
+        expect(result).to eq({ exists: false, expires_in: 0 })
+      end
+
+      it "returns exists: false and 0 when the session has actually timed out, without " \
+        "triggering Devise's sign-out/401 behaviour" do
+        last_request_at = Time.now.utc.to_i - (Devise.timeout_in.to_i + 60)
+        warden_session = { 'last_request_at' => last_request_at }
+        # Fetching with run_callbacks: false means Warden won't sign the user out or throw here,
+        # unlike a real `current_user` call once the session has timed out; the returned user
+        # object itself is still present, and it's the expires_in calculation below that
+        # determines the session is no longer active.
+        allow(warden).to receive(:user).with(scope: :user, run_callbacks: false).and_return(double("user"))
+        allow(controller).to receive(:session).and_return({ 'warden.user.user.session' => warden_session })
+        result = config.session_active_proc.call(controller)
+        expect(result).to eq({ exists: false, expires_in: 0 })
+      end
+
+      it "returns exists: false and 0 when there is no warden proxy on the request" do
+        allow(controller).to receive_message_chain(:request, :env).and_return({})
         result = config.session_active_proc.call(controller)
         expect(result).to eq({ exists: false, expires_in: 0 })
       end


### PR DESCRIPTION
When the session becomes stale we are seeing Warden raise a session timeout error as opposed to just returning the expected JSON 

<img width="1437" height="1137" alt="image" src="https://github.com/user-attachments/assets/bba06451-f1e2-4bb3-8604-1a862201b591" />
